### PR TITLE
test(customer): align tests with sonar-driven hardening

### DIFF
--- a/services/customer-service/test/integration/test_customer_repository_and_api.py
+++ b/services/customer-service/test/integration/test_customer_repository_and_api.py
@@ -405,7 +405,7 @@ def test_When_AdminSuspendsCustomer_Expect_StatusChangeIsLogged(
 
     # Assert
     assert response.status_code == 200
-    assert f"Customer status suspend customer_id={customer_id}" in caplog.text
+    assert "Customer status suspend completed" in caplog.text
 
 
 def test_When_UnexpectedErrorOccurs_Expect_InternalServerErrorAndExceptionLogged(

--- a/services/customer-service/test/unit/infrastructure/test_runtime_and_messaging.py
+++ b/services/customer-service/test/unit/infrastructure/test_runtime_and_messaging.py
@@ -368,8 +368,10 @@ def test_When_DockerfileIsRead_Expect_UvRuntimeUsesServiceSourceAndPersistentDat
     assert "FROM python:3.11-slim" in dockerfile
     assert "WORKDIR /app" in dockerfile
     assert "uv sync --frozen --no-dev --no-install-project" in dockerfile
-    assert "COPY . ." in dockerfile
+    assert "COPY internal/ ./internal/" in dockerfile
+    assert "COPY main.py ./" in dockerfile
     assert "mkdir -p data" in dockerfile
+    assert "USER app" in dockerfile
     assert (
         '.venv/bin/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"'
         in dockerfile


### PR DESCRIPTION
## Objetivo

Alinear los tests de `customer-service` con los cambios recientes hechos para responder hallazgos de SonarCloud.

## Tipo de cambio

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Test
- [ ] Docs
- [ ] Chore / CI

## Servicio o módulo afectado

- [ ] booking-service
- [ ] inventory-service
- [x] customer-service
- [ ] payment-service
- [ ] shared
- [ ] docs
- [ ] deploy
- [ ] .github / ci

## Qué se hizo

- se actualizó el test de integración del cambio de estado para esperar el nuevo mensaje de log sin `customer_id`
- se actualizó el test del Dockerfile para validar el copiado explícito y el uso de `USER app`

## Cómo se probó

- [x] Validación manual
- [ ] Pruebas unitarias
- [ ] Pruebas de integración
- [ ] No aplica

Detalle de prueba realizado:

```txt
Se revisaron los logs del workflow fallido de SonarCloud y se ajustaron exactamente los dos tests que seguían validando el comportamiento anterior.
```

## Checklist

- [x] Leí la documentación del flujo Git
- [x] Mi rama sale de `develop`
- [x] El PR apunta a `develop`
- [x] Hice commits claros y atómicos
- [x] No rompí contratos existentes
- [x] Documenté cambios necesarios

## Riesgos u observaciones

Este PR solo alinea tests con cambios ya aplicados previamente en `develop` para resolver hallazgos de SonarCloud.