### PR TITLE
merge(develop): promote customer-service and sonar fixes to main

### DIFF
--- a/services/customer-service/Dockerfile
+++ b/services/customer-service/Dockerfile
@@ -8,11 +8,17 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir uv
 
+RUN addgroup --system app && adduser --system --ingroup app app
+
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
-COPY . .
-RUN mkdir -p data && uv sync --frozen --no-dev
+COPY internal/ ./internal/
+COPY main.py ./
+
+RUN mkdir -p data && chown -R app:app /app && uv sync --frozen --no-dev
+
+USER app
 
 EXPOSE 8000
 

--- a/services/customer-service/internal/interfaces/rest/app.py
+++ b/services/customer-service/internal/interfaces/rest/app.py
@@ -191,7 +191,7 @@ def _log_auth_event(action: str, *, email: str) -> None:
 
 
 def _log_status_change(action: str, *, customer_id: str) -> None:
-    logger.info("Customer status %s customer_id=%s", action, customer_id)
+    logger.info("Customer status %s completed", action)
 
 
 def _configure_logging() -> None:

--- a/services/customer-service/internal/interfaces/rest/schemas.py
+++ b/services/customer-service/internal/interfaces/rest/schemas.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
+EXAMPLE_CUSTOMER_EMAIL = "jane@example.com"
+
 
 def _to_camel(string: str) -> str:
     parts = string.split("_")
@@ -17,7 +19,7 @@ class RegisterCustomerRequest(CamelCaseModel):
     )
     email: EmailStr = Field(
         description="Unique customer email address",
-        examples=["jane@example.com"],
+        examples=[EXAMPLE_CUSTOMER_EMAIL],
     )
     phone: str | None = Field(
         default=None,
@@ -34,7 +36,7 @@ class RegisterCustomerRequest(CamelCaseModel):
 class LoginRequest(CamelCaseModel):
     email: EmailStr = Field(
         description="Registered customer email address",
-        examples=["jane@example.com"],
+        examples=[EXAMPLE_CUSTOMER_EMAIL],
     )
     password: str = Field(
         description="Plain password for authentication",
@@ -77,7 +79,7 @@ class CustomerResponse(CamelCaseModel):
     name: str = Field(description="Customer full name", examples=["Jane Doe"])
     email: str = Field(
         description="Customer email address",
-        examples=["jane@example.com"],
+        examples=[EXAMPLE_CUSTOMER_EMAIL],
     )
     phone: str | None = Field(
         default=None,

--- a/services/customer-service/test/integration/test_customer_repository_and_api.py
+++ b/services/customer-service/test/integration/test_customer_repository_and_api.py
@@ -405,7 +405,7 @@ def test_When_AdminSuspendsCustomer_Expect_StatusChangeIsLogged(
 
     # Assert
     assert response.status_code == 200
-    assert f"Customer status suspend customer_id={customer_id}" in caplog.text
+    assert "Customer status suspend completed" in caplog.text
 
 
 def test_When_UnexpectedErrorOccurs_Expect_InternalServerErrorAndExceptionLogged(

--- a/services/customer-service/test/unit/infrastructure/test_runtime_and_messaging.py
+++ b/services/customer-service/test/unit/infrastructure/test_runtime_and_messaging.py
@@ -368,8 +368,10 @@ def test_When_DockerfileIsRead_Expect_UvRuntimeUsesServiceSourceAndPersistentDat
     assert "FROM python:3.11-slim" in dockerfile
     assert "WORKDIR /app" in dockerfile
     assert "uv sync --frozen --no-dev --no-install-project" in dockerfile
-    assert "COPY . ." in dockerfile
+    assert "COPY internal/ ./internal/" in dockerfile
+    assert "COPY main.py ./" in dockerfile
     assert "mkdir -p data" in dockerfile
+    assert "USER app" in dockerfile
     assert (
         '.venv/bin/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"'
         in dockerfile


### PR DESCRIPTION
## Objetivo

Promover a `main` los cambios ya validados en `develop`, incluyendo `customer-service`, los ajustes de CI/Sonar y las correcciones recientes motivadas por SonarCloud.

## Tipo de cambio

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Test
- [ ] Docs
- [ ] Chore / CI

## Servicio o módulo afectado

- [ ] booking-service
- [ ] inventory-service
- [x] customer-service
- [ ] payment-service
- [ ] shared
- [ ] docs
- [x] deploy
- [x] .github / ci

## Qué se hizo

- se promueven a `main` los cambios ya aprobados en `develop`
- se incluye `customer-service` junto con su documentación y runtime Docker
- se incluyen los ajustes de `python-quality.yml`, `sonar.yml` y las correcciones recientes de SonarCloud

## Cómo se probó

- [x] Validación manual
- [ ] Pruebas unitarias
- [ ] Pruebas de integración
- [ ] No aplica

Detalle de prueba realizado:

```txt
Se verificó que el último run de SonarCloud en develop (`24762690683`) terminó exitosamente después del merge de la PR #7.
```

## Checklist

- [x] Leí la documentación del flujo Git
- [x] Mi rama sale de `develop`
- [x] El PR apunta a `main`
- [x] Hice commits claros y atómicos
- [x] No rompí contratos existentes
- [x] Documenté cambios necesarios

## Riesgos u observaciones

`main` exige 1 aprobación antes de mergear. Este PR busca hacer la promoción de forma normal, sin bypass.